### PR TITLE
Dependency org.springframework:spring-beans, leading to CVE problem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>spring-boot-parent</artifactId>
         <groupId>org.springframework.boot</groupId>
-        <version>2.3.4.RELEASE</version>
+        <version>2.5.14</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
Hi, In **/**，there is a dependency **org.springframework:spring-beans:5.2.9.RELEASE** that calls the risk method.

[CVE-2022-22970](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-22970)

The scope of this CVE affected version is **[,5.2.22.RELEASE) [5.3.0,5.3.20)**

After further analysis, in this project, the main Api called is **org.springframework.beans.CachedIntrospectionResults: introspectInterfaces(java.lang.Class,java.lang.Class)V**

Risk method repair link : [GitHub](https://github.com/spring-projects/spring-framework/commit/83186b689f11f5e6efe7ccc08fdeb92f66fcd583)

**CVE Bug Invocation Path--**

**Path Length : 7**

```
io.dataease.plugins.common.util.PluginCommonUtil: copyBean(java.lang.Object,java.lang.Object)Ljava.lang.Object; /download/apache-maven-3.6.3/repository_mount/io/swagger/swagger-core/1.5.22/swagger-core-1.5.22.jar
org.springframework.beans.BeanUtils: copyProperties(java.lang.Object,java.lang.Object)V /download/apache-maven-3.6.3/repository_mount/io/swagger/swagger-core/1.5.22/swagger-core-1.5.22.jar
org.springframework.beans.BeanUtils: copyProperties(java.lang.Object,java.lang.Object,java.lang.Class,java.lang.String[])V /download/apache-maven-3.6.3/repository_mount/io/swagger/swagger-core/1.5.22/swagger-core-1.5.22.jar
org.springframework.beans.BeanUtils: getPropertyDescriptors(java.lang.Class)[Ljava.beans.PropertyDescriptor; /download/apache-maven-3.6.3/repository_mount/io/swagger/swagger-core/1.5.22/swagger-core-1.5.22.jar
org.springframework.beans.CachedIntrospectionResults: forClass(java.lang.Class)Lorg.springframework.beans.CachedIntrospectionResults; /download/apache-maven-3.6.3/repository_mount/io/swagger/swagger-core/1.5.22/swagger-core-1.5.22.jar
org.springframework.beans.CachedIntrospectionResults: init(java.lang.Class)V /download/apache-maven-3.6.3/repository_mount/io/swagger/swagger-core/1.5.22/swagger-core-1.5.22.jar
org.springframework.beans.CachedIntrospectionResults: introspectInterfaces(java.lang.Class,java.lang.Class)V
```
**Dependency tree--**

```
[INFO] io.dataease:dataease-plugin-interface:jar:1.18.4
[INFO] +- io.dataease:dataease-plugin-common:jar:1.18.4:compile
[INFO] +- org.jasig.cas.client:cas-client-core:jar:3.5.0:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.11.2:compile
[INFO] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.11.2:compile
[INFO] |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.11.2:compile
[INFO] |  \- org.slf4j:slf4j-api:jar:1.7.30:compile
[INFO] +- com.vladsch.flexmark:flexmark-all:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-ext-abbreviation:jar:0.62.2:compile
[INFO] |  |  \- com.vladsch.flexmark:flexmark-util:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-ext-admonition:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-ext-anchorlink:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-ext-aside:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-ext-attributes:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-ext-autolink:jar:0.62.2:compile
[INFO] |  |  \- org.nibor.autolink:autolink:jar:0.6.0:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-ext-definition:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-ext-emoji:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-ext-enumerated-reference:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-ext-escaped-character:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-ext-footnotes:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-ext-gfm-issues:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-ext-gfm-strikethrough:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-ext-gfm-tasklist:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-ext-gfm-users:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-ext-gitlab:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-ext-jekyll-front-matter:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-ext-jekyll-tag:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-ext-media-tags:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-ext-macros:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-ext-ins:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-ext-xwiki-macros:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-ext-superscript:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-ext-tables:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-ext-toc:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-ext-typographic:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-ext-wikilink:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-ext-yaml-front-matter:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-ext-youtube-embedded:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-html2md-converter:jar:0.62.2:compile
[INFO] |  |  \- org.jsoup:jsoup:jar:1.11.3:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-jira-converter:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-pdf-converter:jar:0.62.2:compile
[INFO] |  |  +- com.openhtmltopdf:openhtmltopdf-core:jar:1.0.0:compile
[INFO] |  |  +- com.openhtmltopdf:openhtmltopdf-pdfbox:jar:1.0.0:compile
[INFO] |  |  |  +- org.apache.pdfbox:xmpbox:jar:2.0.16:compile
[INFO] |  |  |  \- de.rototor.pdfbox:graphics2d:jar:0.24:compile
[INFO] |  |  +- com.openhtmltopdf:openhtmltopdf-rtl-support:jar:1.0.0:compile
[INFO] |  |  |  \- com.ibm.icu:icu4j:jar:59.1:compile
[INFO] |  |  \- com.openhtmltopdf:openhtmltopdf-jsoup-dom-converter:jar:1.0.0:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-profile-pegdown:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-util-ast:jar:0.62.2:compile
[INFO] |  |  \- org.jetbrains:annotations:jar:15.0:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-util-builder:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-util-collection:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-util-data:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-util-dependency:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-util-format:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-util-html:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-util-misc:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-util-options:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-util-sequence:jar:0.62.2:compile
[INFO] |  +- com.vladsch.flexmark:flexmark-util-visitor:jar:0.62.2:compile
[INFO] |  \- com.vladsch.flexmark:flexmark-youtrack-converter:jar:0.62.2:compile
[INFO] +- com.alibaba:easyexcel:jar:2.1.7:compile
[INFO] |  +- org.apache.poi:poi:jar:3.17:compile
[INFO] |  +- org.apache.poi:poi-ooxml:jar:3.17:compile
[INFO] |  |  +- org.apache.poi:poi-ooxml-schemas:jar:3.17:compile
[INFO] |  |  |  \- org.apache.xmlbeans:xmlbeans:jar:2.6.0:compile
[INFO] |  |  |     \- stax:stax-api:jar:1.0.1:compile
[INFO] |  |  \- com.github.virtuald:curvesapi:jar:1.04:compile
[INFO] |  +- cglib:cglib:jar:3.1:compile
[INFO] |  |  \- org.ow2.asm:asm:jar:4.2:compile
[INFO] |  \- org.ehcache:ehcache:jar:3.8.1:compile
[INFO] |     \- org.glassfish.jaxb:jaxb-runtime:jar:2.3.3:compile
[INFO] |        +- jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.3:compile
[INFO] |        +- org.glassfish.jaxb:txw2:jar:2.3.3:compile
[INFO] |        +- com.sun.istack:istack-commons-runtime:jar:3.0.11:compile
[INFO] |        \- com.sun.activation:jakarta.activation:jar:1.2.2:runtime
[INFO] +- com.itextpdf:itextpdf:jar:5.5.9:compile
[INFO] +- org.apache.pdfbox:pdfbox:jar:3.0.0-alpha3:compile
[INFO] |  +- org.apache.pdfbox:io:jar:3.0.0-alpha3:compile
[INFO] |  +- org.apache.pdfbox:fontbox:jar:3.0.0-alpha3:compile
[INFO] |  \- commons-logging:commons-logging:jar:1.2:compile
[INFO] +- org.springframework.boot:spring-boot-starter:jar:2.3.4.RELEASE:compile
[INFO] |  +- org.springframework.boot:spring-boot:jar:2.3.4.RELEASE:compile
[INFO] |  |  \- org.springframework:spring-context:jar:5.2.9.RELEASE:compile
[INFO] |  +- org.springframework.boot:spring-boot-autoconfigure:jar:2.3.4.RELEASE:compile
[INFO] |  +- org.springframework.boot:spring-boot-starter-logging:jar:2.3.4.RELEASE:compile
[INFO] |  |  +- ch.qos.logback:logback-classic:jar:1.2.3:compile
[INFO] |  |  |  \- ch.qos.logback:logback-core:jar:1.2.3:compile
[INFO] |  |  +- org.apache.logging.log4j:log4j-to-slf4j:jar:2.13.3:compile
[INFO] |  |  |  \- org.apache.logging.log4j:log4j-api:jar:2.13.3:compile
[INFO] |  |  \- org.slf4j:jul-to-slf4j:jar:1.7.30:compile
[INFO] |  +- jakarta.annotation:jakarta.annotation-api:jar:1.3.5:compile
[INFO] |  +- org.springframework:spring-core:jar:5.2.9.RELEASE:compile
[INFO] |  |  \- org.springframework:spring-jcl:jar:5.2.9.RELEASE:compile
[INFO] |  \- org.yaml:snakeyaml:jar:1.26:compile
[INFO] +- org.springframework.boot:spring-boot-starter-web:jar:2.3.4.RELEASE:compile
[INFO] |  +- org.springframework.boot:spring-boot-starter-json:jar:2.3.4.RELEASE:compile
[INFO] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.11.2:compile
[INFO] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.11.2:compile
[INFO] |  |  \- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.11.2:compile
[INFO] |  +- org.springframework.boot:spring-boot-starter-tomcat:jar:2.3.4.RELEASE:compile
[INFO] |  |  +- org.apache.tomcat.embed:tomcat-embed-core:jar:9.0.38:compile
[INFO] |  |  \- org.apache.tomcat.embed:tomcat-embed-websocket:jar:9.0.38:compile
[INFO] |  +- org.springframework:spring-web:jar:5.2.9.RELEASE:compile
[INFO] |  |  \- org.springframework:spring-beans:jar:5.2.9.RELEASE:compile
[INFO] |  \- org.springframework:spring-webmvc:jar:5.2.9.RELEASE:compile
[INFO] |     +- org.springframework:spring-aop:jar:5.2.9.RELEASE:compile
[INFO] |     \- org.springframework:spring-expression:jar:5.2.9.RELEASE:compile
[INFO] +- org.projectlombok:lombok:jar:1.18.12:compile
[INFO] +- org.apache.commons:commons-lang3:jar:3.10:compile
[INFO] +- org.apache.commons:commons-collections4:jar:4.4:compile
[INFO] +- org.apache.commons:commons-text:jar:1.8:compile
[INFO] +- commons-codec:commons-codec:jar:1.14:compile
[INFO] +- commons-beanutils:commons-beanutils-core:jar:1.8.0:compile
[INFO] +- org.springframework.boot:spring-boot-starter-data-ldap:jar:2.3.4.RELEASE:compile
[INFO] |  \- org.springframework.data:spring-data-ldap:jar:2.3.4.RELEASE:compile
[INFO] |     +- org.springframework.ldap:spring-ldap-core:jar:2.3.3.RELEASE:compile
[INFO] |     |  \- org.springframework:spring-tx:jar:5.2.9.RELEASE:compile
[INFO] |     \- org.springframework.data:spring-data-commons:jar:2.3.4.RELEASE:compile
[INFO] +- org.apache.httpcomponents:httpclient:jar:4.5.13:compile
[INFO] |  \- org.apache.httpcomponents:httpcore:jar:4.4.13:compile
[INFO] +- org.antlr:antlr-complete:jar:3.5.2:compile
[INFO] |  +- org.antlr:antlr:jar:3.5.2:compile
[INFO] |  |  \- org.antlr:ST4:jar:4.0.8:compile
[INFO] |  +- org.antlr:antlr-runtime:jar:3.5.2:compile
[INFO] |  \- org.antlr:gunit:jar:3.5.2:compile
[INFO] |     +- junit:junit:jar:4.13:compile
[INFO] |     |  \- org.hamcrest:hamcrest-core:jar:2.2:compile
[INFO] |     |     \- org.hamcrest:hamcrest:jar:2.2:compile
[INFO] |     \- org.antlr:stringtemplate:jar:3.2.1:compile
[INFO] |        \- antlr:antlr:jar:2.7.7:compile
[INFO] +- cn.hutool:hutool-all:jar:5.7.4:compile
[INFO] +- org.mybatis.spring.boot:mybatis-spring-boot-starter:jar:2.1.4:compile
[INFO] |  +- org.springframework.boot:spring-boot-starter-jdbc:jar:2.3.4.RELEASE:compile
[INFO] |  |  +- com.zaxxer:HikariCP:jar:3.4.5:compile
[INFO] |  |  \- org.springframework:spring-jdbc:jar:5.2.9.RELEASE:compile
[INFO] |  +- org.mybatis.spring.boot:mybatis-spring-boot-autoconfigure:jar:2.1.4:compile
[INFO] |  +- org.mybatis:mybatis:jar:3.5.6:compile
[INFO] |  \- org.mybatis:mybatis-spring:jar:2.0.6:compile
[INFO] +- com.github.xiaoymin:knife4j-spring-boot-starter:jar:3.0.3:compile
[INFO] |  +- com.github.xiaoymin:knife4j-spring-boot-autoconfigure:jar:3.0.3:compile
[INFO] |  |  +- com.github.xiaoymin:knife4j-spring:jar:3.0.3:compile
[INFO] |  |  |  +- com.github.xiaoymin:knife4j-annotations:jar:3.0.3:compile
[INFO] |  |  |  |  +- io.swagger:swagger-annotations:jar:1.5.22:compile
[INFO] |  |  |  |  \- io.swagger.core.v3:swagger-annotations:jar:2.1.2:compile
[INFO] |  |  |  +- com.github.xiaoymin:knife4j-core:jar:3.0.3:compile
[INFO] |  |  |  +- org.javassist:javassist:jar:3.25.0-GA:compile
[INFO] |  |  |  +- io.springfox:springfox-swagger2:jar:3.0.0:compile
[INFO] |  |  |  |  +- io.springfox:springfox-spi:jar:3.0.0:compile
[INFO] |  |  |  |  +- io.springfox:springfox-schema:jar:3.0.0:compile
[INFO] |  |  |  |  +- io.springfox:springfox-swagger-common:jar:3.0.0:compile
[INFO] |  |  |  |  +- io.springfox:springfox-spring-web:jar:3.0.0:compile
[INFO] |  |  |  |  |  \- io.github.classgraph:classgraph:jar:4.8.83:compile
[INFO] |  |  |  |  +- io.springfox:springfox-spring-webflux:jar:3.0.0:compile
[INFO] |  |  |  |  \- org.mapstruct:mapstruct:jar:1.3.1.Final:runtime
[INFO] |  |  |  +- io.springfox:springfox-spring-webmvc:jar:3.0.0:compile
[INFO] |  |  |  |  \- io.springfox:springfox-core:jar:3.0.0:compile
[INFO] |  |  |  |     \- net.bytebuddy:byte-buddy:jar:1.10.14:compile
[INFO] |  |  |  +- io.springfox:springfox-oas:jar:3.0.0:compile
[INFO] |  |  |  |  \- io.swagger.core.v3:swagger-models:jar:2.1.2:compile
[INFO] |  |  |  +- io.springfox:springfox-bean-validators:jar:3.0.0:compile
[INFO] |  |  |  +- io.swagger:swagger-models:jar:1.5.22:compile
[INFO] |  |  |  \- io.swagger:swagger-core:jar:1.5.22:compile
[INFO] |  |  |     +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.11.2:compile
[INFO] |  |  |     +- com.google.guava:guava:jar:27.0.1-android:compile
[INFO] |  |  |     |  +- com.google.guava:failureaccess:jar:1.0.1:compile
[INFO] |  |  |     |  +- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
[INFO] |  |  |     |  +- com.google.code.findbugs:jsr305:jar:3.0.2:compile
[INFO] |  |  |     |  +- org.checkerframework:checker-compat-qual:jar:2.5.2:compile
[INFO] |  |  |     |  +- com.google.errorprone:error_prone_annotations:jar:2.2.0:compile
[INFO] |  |  |     |  +- com.google.j2objc:j2objc-annotations:jar:1.1:compile
[INFO] |  |  |     |  \- org.codehaus.mojo:animal-sniffer-annotations:jar:1.17:compile
[INFO] |  |  |     \- javax.validation:validation-api:jar:2.0.1.Final:compile
[INFO] |  |  \- io.springfox:springfox-boot-starter:jar:3.0.0:compile
[INFO] |  |     +- io.springfox:springfox-data-rest:jar:3.0.0:compile
[INFO] |  |     +- org.springframework.plugin:spring-plugin-core:jar:2.0.0.RELEASE:compile
[INFO] |  |     \- org.springframework.plugin:spring-plugin-metadata:jar:2.0.0.RELEASE:compile
[INFO] |  \- com.github.xiaoymin:knife4j-spring-ui:jar:3.0.3:compile
[INFO] +- com.alibaba:druid:jar:1.2.8:compile
[INFO] |  \- javax.annotation:javax.annotation-api:jar:1.3.2:compile
[INFO] +- com.google.code.gson:gson:jar:2.8.6:compile
[INFO] \- org.springframework.boot:spring-boot-starter-validation:jar:2.3.4.RELEASE:compile
[INFO]    +- org.glassfish:jakarta.el:jar:3.0.3:compile
[INFO]    \- org.hibernate.validator:hibernate-validator:jar:6.1.5.Final:compile
[INFO]       +- jakarta.validation:jakarta.validation-api:jar:2.0.2:compile
[INFO]       +- org.jboss.logging:jboss-logging:jar:3.4.1.Final:compile
[INFO]       \- com.fasterxml:classmate:jar:1.5.1:compile
```

**_Suggested solutions:_**

Update dependency version @fit2cloud-chenyw 

Thank you very much.
